### PR TITLE
Fix bidirectional sync when clearing all selections (Issue #6)

### DIFF
--- a/app.py
+++ b/app.py
@@ -275,10 +275,8 @@ def on_obcode_change(event):
         return
 
     selected_obcodes = obcode_mc.value
-    if not selected_obcodes:
-        return
 
-    # Get fiber IDs for selected OB codes
+    # Get fiber IDs for selected OB codes (empty list if no OB codes selected)
     obcode_to_fibers = state["visit_data"]["obcode_to_fibers"]
     fiber_ids = []
     for obcode in selected_obcodes:
@@ -315,10 +313,8 @@ def on_fiber_change(event):
         return
 
     selected_fibers = fibers_mc.value
-    if not selected_fibers:
-        return
 
-    # Get OB codes for selected fiber IDs
+    # Get OB codes for selected fiber IDs (empty set if no fibers selected)
     fiber_to_obcode = state["visit_data"]["fiber_to_obcode"]
     obcodes = set()
     for fiber_id in selected_fibers:


### PR DESCRIPTION
Remove early returns in on_obcode_change() and on_fiber_change() callbacks that prevented clearing the corresponding widget when the last selected item was removed.

Now when all selections are cleared from one widget, the other widget is properly cleared as well, maintaining bidirectional synchronization.

Fixes #6