### PR TITLE
add prefix to the app URL

### DIFF
--- a/launch_app.bash
+++ b/launch_app.bash
@@ -61,6 +61,7 @@ if [[ "$MODE" == "dev" ]]; then
     --address "$ADDRESS" \
     --port "$PORT" \
     --allow-websocket-origin="$ORIGIN:$PORT" \
+    --prefix quicklook \
     --dev
 else
   echo "Running in production mode with multi-threading"
@@ -69,6 +70,7 @@ else
     --address "$ADDRESS" \
     --port "$PORT" \
     --allow-websocket-origin="$ORIGIN:$PORT" \
+    --prefix quicklook \
     --num-threads 8
 fi
 


### PR DESCRIPTION
This pull request updates the `launch_app.bash` script to add a URL prefix for both development and production modes. The main change is the inclusion of the `--prefix quicklook` argument when launching the application, which helps namespace the app under a specific URL path.

Application launch configuration:

* Added the `--prefix quicklook` argument to the application launch command for both development and production modes in `launch_app.bash`, ensuring the app is served under the `/quicklook` URL prefix. [[1]](diffhunk://#diff-358a6476097d01ea16dbb0e503061b32f95322fc4dd838475dfd5a5e74e5dd6bR64) [[2]](diffhunk://#diff-358a6476097d01ea16dbb0e503061b32f95322fc4dd838475dfd5a5e74e5dd6bR73)