### PR TITLE
Add automatic y-axis scaling for 1D spectra plots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,8 +253,9 @@ pfs_quicklook/
 - Uses joblib Parallel for multi-core processing
 - Returns: List of (arm, transformed_array, metadata, error) tuples
 
-**`build_1d_bokeh_figure_single_visit(datastore, base_collection, visit, fiber_ids, ylim)`**:
+**`build_1d_bokeh_figure_single_visit(datastore, base_collection, visit, fiber_ids, ylim=None)`**:
 - Creates interactive Bokeh 1D spectra plot
+- Automatically calculates y-axis range using percentile-based method (0.5th-99.5th percentile) if ylim is None
 - Returns: Bokeh figure object
 
 **`build_1d_spectra_as_image(datastore, base_collection, visit, fiber_ids, scale_algo)`**:


### PR DESCRIPTION
- Add compute_percentile_ylim() function with percentile-based calculation
- Use 0.5th-99.9th percentiles to handle emission lines robustly
- Apply bitmask filtering for bad pixels (NO_DATA, SAT, BAD, CR)
- Add 50% upper margin to accommodate strong emission lines
- Update build_1d_bokeh_figure_single_visit() to use automatic ylim by default