### PR TITLE
Enable browser reload to reload .env configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -1216,8 +1216,11 @@ def on_session_created():
     # when the callback fires. In multi-session scenarios, only one session's state
     # is checked/updated per callback invocation, which is a known limitation.
     #
-    # NOTE: The refresh_interval is read only once during first registration.
-    # Changes to VISIT_REFRESH_INTERVAL in .env require server restart to take effect.
+    # NOTE: The refresh_interval used for the periodic callback period is read only once
+    # during first registration. Changes to VISIT_REFRESH_INTERVAL in .env will only
+    # affect the callback period after a server restart. However, visit discovery itself
+    # uses session-specific config values from get_config(), so each session can have
+    # different datastore/collection/obsdate values that reload properly on browser refresh.
     global _periodic_callbacks_registered
     with _periodic_callbacks_lock:
         if not _periodic_callbacks_registered:


### PR DESCRIPTION
## Summary

Enable browser reload to reload `.env` configuration without requiring server restart. Users can now modify `.env` file and see changes by simply reloading the browser (F5).

## Key Changes

### Session-Specific Configuration
- Add session-specific config storage in session state
- Add `get_config()` helper to retrieve per-session configuration
- Update all data loading functions to use session config instead of global variables
- Update sidebar config display dynamically on session start
- `reload_config()` now called on every browser session start (page load/reload)

### Periodic Callback Management
- Implement thread-safe periodic callback registration using `threading.Lock()`
- Prevent callback accumulation across browser reloads
- Remove redundant callback registrations in `trigger_visit_refresh()`
- Fix memory leak from duplicate callback registrations

### Code Quality Improvements
- Replace hardcoded magic numbers with named constants (`VISIT_REFRESH_INTERVAL`)
- Use placeholder text for config widget before session initialization
- Consistent field ordering across UI and log messages
- Comprehensive documentation of multi-session behavior and limitations

## Implementation Details

**Configuration Reloading:**
- Each browser session gets independent configuration state
- Config values (datastore, collection, obsdate) reload on browser refresh
- Session-specific config isolated via `pn.state.curdoc.session_context.app_state`

**Thread Safety:**
- Global `_periodic_callbacks_lock` prevents race conditions during callback registration
- Atomic check-and-register operation ensures callbacks registered exactly once

## Known Limitations

**Multi-Session Scenarios:**
- Periodic callbacks are shared across all sessions (server-level)
- Callbacks only update whichever session is "current" when they fire
- This is acceptable for typical single-user observatory scenarios
- Future improvement: implement per-session callback mechanism

**Refresh Interval:**
- The callback period for `VISIT_REFRESH_INTERVAL` is read only once at first registration
- Changes to this value in `.env` require server restart to take effect
- Other config values (datastore, collection, obsdate) reload properly on browser refresh

## Testing

Verified that:
- ✅ Browser reload picks up changes to DATASTORE, BASE_COLLECTION, OBSDATE_UTC
- ✅ No callback accumulation across multiple browser reloads
- ✅ Thread-safe callback registration with concurrent session starts
- ✅ Configuration display updates correctly for each session
- ✅ No memory leaks from periodic callbacks

## Review Comments Addressed

All Copilot review comments have been addressed:
- Thread safety for callback registration
- Documentation of multi-session limitations
- Clarification of refresh_interval reload behavior
- Placeholder text improvements
- Field ordering consistency
- Code quality improvements (named constants, etc.)
