### PR TITLE
Set spectro_cbg text color to white when selected

### DIFF
--- a/app.py
+++ b/app.py
@@ -129,9 +129,6 @@ spectro_cbg = pn.widgets.CheckButtonGroup(
     sizing_mode="stretch_width",
     stylesheets=[
         """
-        .bk-btn-group .bk-btn.bk-btn-primary.bk-active {
-            color: white !important;
-        }
         .bk-btn.bk-btn-primary.bk-active {
             color: white !important;
         }


### PR DESCRIPTION
This PR improves the readability of the Spectrograph CheckButtonGroup widget by setting the text color to white when buttons are selected.

## Changes
- Added CSS stylesheets to `spectro_cbg` widget to apply white text color to active/selected buttons
- Uses `.bk-btn-primary.bk-active` selector to target the selected state

## Motivation
When buttons are selected in the CheckButtonGroup with `button_style="outline"`, they get filled with the primary color. The text color needs to be white for better contrast and readability in the selected state.