### PR TITLE
Add spectrograph column to pfsConfig table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,10 @@ This is a web application for visualizing 2D and 1D spectral data from the PFS (
 - **pfsConfig Tab**: Fiber configuration and pointing information (displayed first)
   - Visit header: pfsDesignId (hex), RA/Dec boresight, position angle, arms, design name
   - Tabulator widget: Interactive table with 250 rows/page
-  - Columns: fiberId, objId, obCode, ra, dec, catId, targetType, fiberStatus, proposalId
+  - Columns: fiberId, spectrograph, objId, obCode, ra, dec, catId, targetType, fiberStatus, proposalId
+  - Column display customization:
+    - Spectrograph: center-aligned
+    - Catalog ID: right-aligned, no thousand separators
   - Header filtering on all columns except ra/dec
   - Visual styling:
     - SCIENCE+GOOD: Bold text (important targets)

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import threading
 
 import numpy as np
 import panel as pn
+from bokeh.models.widgets.tables import NumberFormatter
 from joblib import Parallel, delayed
 from loguru import logger
 
@@ -381,17 +382,40 @@ def load_data_callback(event=None):
                 "objId": 200,  # Wide enough for 64-bit integers (up to 20 digits)
                 "obCode": 300,  # Double width for observation codes
             },
+            text_align={"spectrograph": "center", "catId": "right"},
+            formatters={
+                "catId": NumberFormatter(
+                    format="0"
+                ),  # Display without thousand separators
+            },
             configuration={
                 "columns": [
-                    {"field": "fiberId", "headerFilter": True},
-                    {"field": "objId", "headerFilter": True},
-                    {"field": "obCode", "headerFilter": True},
-                    {"field": "ra", "headerFilter": False},
-                    {"field": "dec", "headerFilter": False},
-                    {"field": "catId", "headerFilter": True},
-                    {"field": "targetType", "headerFilter": True},
-                    {"field": "fiberStatus", "headerFilter": True},
-                    {"field": "proposalId", "headerFilter": True},
+                    {"field": "fiberId", "headerFilter": True, "title": "Fiber ID"},
+                    {
+                        "field": "spectrograph",
+                        "headerFilter": True,
+                        "title": "Sp",
+                    },
+                    {"field": "objId", "headerFilter": True, "title": "Object ID"},
+                    {"field": "obCode", "headerFilter": True, "title": "OB Code"},
+                    {"field": "ra", "headerFilter": False, "title": "RA"},
+                    {"field": "dec", "headerFilter": False, "title": "Dec"},
+                    {"field": "catId", "headerFilter": True, "title": "Catalog ID"},
+                    {
+                        "field": "targetType",
+                        "headerFilter": True,
+                        "title": "Target Type",
+                    },
+                    {
+                        "field": "fiberStatus",
+                        "headerFilter": True,
+                        "title": "Fiber Status",
+                    },
+                    {
+                        "field": "proposalId",
+                        "headerFilter": True,
+                        "title": "Proposal ID",
+                    },
                 ],
             },
         )
@@ -406,7 +430,7 @@ def load_data_callback(event=None):
 - **pfsDesign ID**: {pfsConfig.pfsDesignId} (0x{pfsConfig.pfsDesignId:016x})
 - **RA**: {pfsConfig.raBoresight:.6f} deg
 - **Dec**: {pfsConfig.decBoresight:.6f} deg
-- **PA**: {pfsConfig.posAng:.6f} deg
+- **PA**: {pfsConfig.posAng:.2f} deg
 - **Arms**: {pfsConfig.arms}
 - **Design Name**: {pfsConfig.designName if hasattr(pfsConfig, 'designName') else 'N/A'}
 """


### PR DESCRIPTION
## Summary

This PR adds a spectrograph column to the pfsConfig table viewer, providing users with immediate visibility of which spectrograph each fiber belongs to.

### Changes

- **New Column**: Add `spectrograph` column (derived from `fiberId` using `pfs.utils.fiberids.FiberIds`)
- **Display Formatting**:
  - Spectrograph column: center-aligned for better readability
  - Catalog ID column: right-aligned with no thousand separators (using `NumberFormatter`)
- **Column Titles**: Add user-friendly column titles (e.g., "Fiber ID", "Object ID", "OB Code") while keeping internal DataFrame column names as lowercase for consistency
- **Code Organization**: Move `FiberIds` import to file header following Python best practices

### Technical Details

**Files Modified**:
- `quicklook_core.py`: 
  - Add `FiberIds` import to PFS imports section
  - Modify `create_pfsconfig_dataframe()` to include spectrograph mapping
- `app.py`:
  - Add `NumberFormatter` import for catalog ID formatting
  - Configure Tabulator with custom column titles, alignment, and formatters
  - Update style function to use correct DataFrame column names
- `CLAUDE.md`: Update documentation to reflect new column and formatting

### Benefits

- Users can quickly identify which spectrograph a fiber belongs to without manual lookup
- Improved table readability with proper alignment and formatting
- Maintains internal code consistency with lowercase DataFrame column names

🤖 Generated with [Claude Code](https://claude.com/claude-code)