### PR TITLE
Add support for "TODAY" keyword in PFS_OBSDATE_UTC configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,13 @@ PFS_DATASTORE="/path/to/your/datastore"
 PFS_BASE_COLLECTION="<your_base_collection_name>"
 
 # observation date to be considered
-# only single data is allowed
-PFS_OBSDATE_UTC=2025-05-23
+# only single date is allowed
+# Format: YYYY-MM-DD (e.g., 2025-05-23)
+# Special value: "TODAY" (case-insensitive) automatically uses today's UTC date
+# Examples:
+#   PFS_OBSDATE_UTC=2025-05-23     # Use specific date
+#   PFS_OBSDATE_UTC="TODAY"        # Use today's date (updated on each session start)
+PFS_OBSDATE_UTC="TODAY"
 
 # Auto-refresh interval for visit list (in seconds)
 # Set to 0 to disable auto-refresh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,7 +456,11 @@ app_state = {
 
 - `PFS_DATASTORE`: Path to Butler datastore (default: `/work/datastore`)
 - `PFS_BASE_COLLECTION`: Base collection name (default: `u/obsproc/s25a/20250520b`)
-- `PFS_OBSDATE_UTC`: Observation date for visit filtering (format: "YYYY-MM-DD", default: today's date in UTC)
+- `PFS_OBSDATE_UTC`: Observation date for visit filtering
+  - Format: "YYYY-MM-DD" (e.g., `2025-11-15`)
+  - Special value: `"TODAY"` (case-insensitive) automatically uses today's UTC date
+  - Default: today's date in UTC if not specified
+  - Example: `PFS_OBSDATE_UTC="TODAY"` updates to current date on each session start
 - `PFS_VISIT_REFRESH_INTERVAL`: Auto-refresh interval in seconds (default: 300, set to 0 to disable)
 - `PFS_APP_HOSTNAME`: Server hostname for deployment (e.g., `your-server.example.com`)
   - **Required for production launch**: Launch script validates current hostname matches this value

--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ You need to have access to one of PFSA servers to run this app. Also, you need a
     # name of the base collection for the reduction
     PFS_BASE_COLLECTION="<collection name for the night>"
 
-    # observation date to be considered (YYYY-MM-DD format)
-    # only single data is allowed
-    PFS_OBSDATE_UTC="2025-05-26"
+    # observation date to be considered
+    # Format: YYYY-MM-DD (e.g., 2025-05-26) or "TODAY" (automatically uses today's UTC date)
+    # only single date is allowed
+    PFS_OBSDATE_UTC="TODAY"
 
     # Auto-refresh interval for visit list (in seconds)
     # Set to 0 to disable auto-refresh


### PR DESCRIPTION
## Summary

This PR implements issue #47, adding support for a special "TODAY" keyword in the `PFS_OBSDATE_UTC` environment variable. This allows users to set the configuration once without needing to manually update the observation date daily.

## Changes

### Core Implementation
- **New helper function** `parse_obsdate_utc()` in [quicklook_core.py](quicklook_core.py)
  - Handles "TODAY" keyword (case-insensitive: "TODAY", "Today", "today", etc.)
  - Returns today's UTC date in YYYY-MM-DD format when "TODAY" is detected
  - Falls back to today's date if value is None or empty
  - Otherwise returns value as-is (assumes YYYY-MM-DD format)
  - Includes comprehensive NumPy-style docstring with examples
  - Logs informative message when "TODAY" keyword is detected

- **Updated configuration loading**
  - Global constant `OBSDATE_UTC` now uses `parse_obsdate_utc()`
  - `reload_config()` function now uses `parse_obsdate_utc()`
  - Ensures "TODAY" keyword works on each session start/reload

### Documentation Updates
- **[CLAUDE.md](CLAUDE.md)**: Added detailed explanation of "TODAY" keyword in Environment Configuration section
- **[README.md](README.md)**: Updated configuration example to use "TODAY" with explanation
- **[.env.example](.env.example)**: Changed default to `PFS_OBSDATE_UTC="TODAY"` with comprehensive comments and examples

## Benefits

✅ **Convenience**: Users can set `.env` once with `PFS_OBSDATE_UTC="TODAY"` instead of daily manual updates  
✅ **Backward compatible**: Existing configurations with explicit dates (e.g., `2025-11-15`) continue to work  
✅ **Session-aware**: "TODAY" is resolved on each session start, ensuring it always uses the current date  
✅ **Case-insensitive**: Supports "TODAY", "Today", "today", and any case variation  
✅ **Well-documented**: Comprehensive documentation in code and user-facing docs  

## Testing Suggestions

- Set `PFS_OBSDATE_UTC="TODAY"` in `.env` and verify it uses today's date
- Test with explicit date (e.g., `PFS_OBSDATE_UTC="2025-11-15"`) to ensure backward compatibility
- Test case variations: "today", "Today", "TODAY"
- Verify session reload behavior (reload browser page)
- Check that the correct date appears in the Configuration Display widget in the sidebar

## Related Issue

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)