### PR TITLE
Fix: Add override=True to load_dotenv() for TODAY keyword to work correctly

### DIFF
--- a/quicklook_core.py
+++ b/quicklook_core.py
@@ -84,7 +84,7 @@ def parse_obsdate_utc(env_value):
 
 
 # Load configuration file
-load_dotenv(verbose=True)
+load_dotenv(override=True, verbose=True)
 
 DATASTORE = os.environ.get("PFS_DATASTORE", "/work/datastore")
 BASE_COLLECTION = os.environ.get("PFS_BASE_COLLECTION", "u/obsproc/s25a/20250520b")


### PR DESCRIPTION
## Issue

After merging PR #48, the "TODAY" keyword feature was not working as expected. When `PFS_OBSDATE_UTC` environment variable was already set in the shell (e.g., from previous runs or system settings), `load_dotenv()` would not override it with the value from `.env` file.

**Symptom**: Warning message "No visits discovered. Visit list will be empty" appeared even when visits for the current date existed in the datastore.

**Root cause**: `load_dotenv(verbose=True)` at module level (line 87) did not include `override=True` parameter, unlike the `reload_config()` function which correctly used `override=True`.

## Fix

Add `override=True` parameter to `load_dotenv()` call at module level:

```python
# Before
load_dotenv(verbose=True)

# After
load_dotenv(override=True, verbose=True)
```

This ensures `.env` file values always take precedence over pre-existing environment variables.

## Impact

✅ **Fixes "TODAY" keyword**: Now works consistently regardless of shell environment  
✅ **Consistent behavior**: Matches `reload_config()` implementation  
✅ **Proper visit discovery**: Visits for current date are now correctly discovered  
✅ **No regression**: Explicit dates (e.g., `2025-11-15`) continue to work as before  

## Testing

- ✅ Verified with `PFS_OBSDATE_UTC="TODAY"` in `.env`
- ✅ Confirmed visits for current date (2025-11-15) are discovered
- ✅ No more "No visits discovered" warning when visits exist
- ✅ Tested with pre-existing `PFS_OBSDATE_UTC` in shell environment

## Related

- Fixes issue introduced in PR #48
- Related to Issue #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)