### PR TITLE
Add MIT License

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # PFS QuickLook Web Application
 
+## License
+
+This software is licensed under the MIT License. See [LICENSE](LICENSE) for full license text.
+
+Copyright (c) 2025 Masato Onodera, Subaru/PFS obsproc team
+
 ## Project Overview
 
 This is a web application for visualizing 2D and 1D spectral data from the PFS (Prime Focus Spectrograph) pipeline. The application is built using Panel and provides an interactive interface for observatory personnel to quickly inspect spectral data during observations.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Masato Onodera, Subaru/PFS obsproc team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ This is a QuickLook tool for PFS observatory operations.
 
 ## License
 
-This software is developed for the Prime Focus Spectrograph (PFS) project.
+This software is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+
+Copyright (c) 2025 Masato Onodera, Subaru/PFS obsproc team
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary

- Add standard MIT License file
- Update README.md with license information
- Update CLAUDE.md with license section

## Changes

### New Files
- `LICENSE` - Standard MIT License text with copyright information

### Modified Files
- `README.md` - Updated License section with link to LICENSE file and copyright notice
- `CLAUDE.md` - Added License section at the beginning of the document

## Notes

- `pyproject.toml` already contained correct license metadata (`license = "MIT"` and classifier), so no changes were needed there
- Copyright holder: Masato Onodera, Subaru/PFS obsproc team
- Year: 2025

🤖 Generated with [Claude Code](https://claude.com/claude-code)