### PR TITLE
Fix Bokeh integer overflow warning for objId in 1D spectra tooltips

### DIFF
--- a/quicklook_core.py
+++ b/quicklook_core.py
@@ -1404,7 +1404,7 @@ def build_1d_bokeh_figure_single_visit(
 
             # pfsConfigから該当fiberの情報を取得
             pfs_sel = pfsConfig.select(fiberId=fid)
-            obj_id = pfs_sel.objId[0]
+            obj_id = str(pfs_sel.objId[0])  # Convert to string to avoid JavaScript integer overflow
             ob_code = pfs_sel.obCode[0]
 
             color = colors[i % len(colors)]


### PR DESCRIPTION
## Summary

Fix the `BokehUserWarning: out of range integer may result in loss of precision` warning that appears when displaying 1D spectra tooltips.

**Root Cause**: objId values are 64-bit integers that can exceed JavaScript's safe integer range (2^53 - 1 = 9,007,199,254,740,991), causing Bokeh to warn about potential precision loss.

**Solution**: Convert objId to string before adding to Bokeh's ColumnDataSource. This allows JavaScript to safely handle any objId value while maintaining the same tooltip display appearance.

## Changes

- [quicklook_core.py:1407](https://github.com/Subaru-SciOp/pfs_quicklook/blob/fix/bokeh-objid-integer-overflow-issue-58/quicklook_core.py#L1407): Convert objId to string in `build_1d_bokeh_figure_single_visit()`

## Test Plan

- [x] Verify no warnings appear when creating 1D spectra plots
- [x] Confirm objId displays correctly in tooltip (tooltip appearance unchanged)
- [x] Verify behavior with large objId values (>2^53)
- [x] Ensure no regressions in 1D spectra plotting functionality

Fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)