### PR TITLE
Fix joblib worker timeout warning in visit discovery

### DIFF
--- a/quicklook_core.py
+++ b/quicklook_core.py
@@ -405,7 +405,12 @@ def discover_visits(
             logger.info(
                 f"Checking {len(new_visits)} new visits for date: {obsdate_utc}"
             )
-            results = Parallel(n_jobs=min(32, len(new_visits)), verbose=1)(
+            results = Parallel(
+                n_jobs=min(32, len(new_visits)),
+                verbose=1,
+                timeout=300,  # 5-minute timeout to handle filesystem I/O delays
+                pre_dispatch='n_jobs'  # Dispatch only n_jobs tasks at a time to reduce I/O contention
+            )(
                 delayed(check_visit_date)(visit) for visit in new_visits
             )
 


### PR DESCRIPTION
## Summary
- Added `timeout=300` parameter to prevent worker process timeouts during filesystem I/O
- Added `pre_dispatch='n_jobs'` to reduce I/O contention and prevent excessive worker spawning
- Resolves intermittent "worker stopped while jobs were given" warning

## Technical Details
- Default `pre_dispatch='2*n_jobs'` causes 64 tasks to be dispatched upfront with n_jobs=32
- New setting dispatches only 32 tasks at a time, reducing parallel filesystem access
- 5-minute timeout provides buffer for NFS/shared filesystem latency spikes
- No performance impact since processing is I/O-bound, not CPU-bound

## Test Plan
- [ ] Test visit discovery with 80+ visits to verify warning no longer appears
- [ ] Verify performance remains acceptable (~1-2 seconds for 84 visits)
- [ ] Check that visit discovery still works correctly with date filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)