### PR TITLE
Fix Bokeh sizing mode warnings for widgets

### DIFF
--- a/app.py
+++ b/app.py
@@ -196,17 +196,15 @@ btn_clear_selection = pn.widgets.Button(
     name="Clear Selection",
     button_type="default",
     min_width=140,
-    sizing_mode="fixed",
+    sizing_mode="stretch_width",
 )
 
 subtract_sky_chk = pn.widgets.Checkbox(name="Sky subtraction", value=True)
 detmap_overlay_switch = pn.widgets.Switch(
     name="Detector Map Overlay",
     value=True,
-    sizing_mode="fixed",
-    width=200,
+    sizing_mode="stretch_width",
     align=("start", "center"),  # Horizontal: left, Vertical: center
-    # margin=(50, 30, 0, 10),
 )
 scale_sel = pn.widgets.Select(
     name="Scale", options=["zscale", "minmax"], value="zscale"


### PR DESCRIPTION
## Summary

- Fixed W-1005 (FIXED_SIZING_MODE) Bokeh warnings on app startup
- Changed `sizing_mode="fixed"` to `sizing_mode="stretch_width"` for two widgets
- Improved consistency with other sidebar widget configurations

## Changes

### Modified Widgets

1. **`btn_clear_selection`**: Changed `sizing_mode` from "fixed" to "stretch_width"
2. **`detmap_overlay_switch`**: Changed `sizing_mode` from "fixed" to "stretch_width"
   - Also removed unnecessary `width=200` parameter

### Before
```
W-1005 (FIXED_SIZING_MODE): 'fixed' sizing mode requires width and height to be set: Button(id='p1062', ...)
W-1005 (FIXED_SIZING_MODE): 'fixed' sizing mode requires width and height to be set: Switch(id='p1050', ...)
```

### After
No warnings on app startup.

## Rationale

- Bokeh's `sizing_mode="fixed"` requires both `width` AND `height` to be set
- These widgets only had `width` specified, causing warnings
- Using `sizing_mode="stretch_width"` is consistent with all other sidebar widgets
- Provides better responsive behavior within sidebar constraints (min_width=280, max_width=400)

## Test Plan

- [x] Start app and verify no W-1005 warnings appear
- [x] Verify widgets render correctly in sidebar
- [x] Verify widgets behave properly when resizing browser window
- [x] Verify all other widgets still use consistent sizing_mode settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)