### PR TITLE
Add badges to README with official brand colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # PFS Quicklook Web App
 
+[![Python Version](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![Panel](https://img.shields.io/badge/Panel-1.8+-0091DA.svg)](https://panel.holoviz.org/)
+[![HoloViews](https://img.shields.io/badge/HoloViews-1.18+-A61C3C.svg)](https://holoviews.org/)
+[![GitHub issues](https://img.shields.io/github/issues/Subaru-SciOp/pfs_quicklook.svg)](https://github.com/Subaru-SciOp/pfs_quicklook/issues)
+[![GitHub last commit](https://img.shields.io/github/last-commit/Subaru-SciOp/pfs_quicklook.svg)](https://github.com/Subaru-SciOp/pfs_quicklook/commits/main)
+[![GitHub stars](https://img.shields.io/github/stars/Subaru-SciOp/pfs_quicklook.svg)](https://github.com/Subaru-SciOp/pfs_quicklook/stargazers)
+
 Web application for quick-look visualization of Prime Focus Spectrograph (PFS) data, designed for summit and remote observers to perform real-time quality assessment during observations.
 
 This app replaces the previous Jupyter notebook-based quicklook tool ([check_quick_reduction_data.ipynb](legacy/check_quick_reduction_data.ipynb)) with a production-ready web interface.


### PR DESCRIPTION
## Summary
- Added comprehensive badge collection to README.md for better project visibility
- Used official brand colors for Panel (#0091DA) and HoloViews (#A61C3C)
- Organized badges in logical groups (tech stack → GitHub stats) for visual consistency

## Changes
- **Python version**: 3.12+ (matches LSST stack)
- **License**: MIT
- **Dependencies**: Panel 1.8+, HoloViews 1.18+
- **GitHub metrics**: Issues, last commit, stars

## Test plan
- [x] Verify badges render correctly on GitHub
- [x] Confirm colors match official branding
- [x] Check visual flow and readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)