### PR TITLE
Add interactive table checkbox selection for fiber selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ This app replaces the previous Jupyter notebook-based quicklook tool ([check_qui
 
 ## Key Features
 
-- **Fiber configuration viewer** with interactive table showing pointing and fiber details
+- **Fiber configuration viewer** with interactive table and checkbox selection
+- **Three-way fiber selection**: Select fibers via table, OB Code, or Fiber ID widgets
 - **Interactive 2D/1D spectral visualization** with zoom, pan, and hover tools
 - **Multi-user support** with per-session state isolation
 - **Automatic visit discovery** with configurable auto-refresh

--- a/docs/user-guide/1d-spectra.md
+++ b/docs/user-guide/1d-spectra.md
@@ -139,9 +139,23 @@ The screenshot shows the interactive individual 1D spectra view in the main pane
 
 ### Selecting Fibers
 
-Before creating individual 1D plots, select which fibers to visualize. You have two methods:
+Before creating individual 1D plots, select which fibers to visualize. You have **three methods**:
 
-#### Method 1: Select by OB Code
+#### Method 1: Select from Target Info Table
+
+The **Target Info** tab displays a table with checkboxes:
+
+1. Switch to the **Target Info** tab
+2. Click checkboxes in the leftmost column to select fibers
+3. **Fiber ID and OB Code widgets automatically update** in sidebar
+4. Use table filtering to find specific fibers:
+   - Filter by OB Code column to show only certain target types
+   - Filter by Fiber Status to exclude broken fibers
+   - Filter by Target Type to show only SCIENCE targets
+
+**Tip**: This is the **fastest method** for selecting multiple specific fibers, especially when combined with table filtering.
+
+#### Method 2: Select by OB Code
 
 **OB Code** (Observation Code) identifies the type of observation or target:
 
@@ -155,10 +169,9 @@ Common examples:
 
 1. Click the **OB Code** dropdown in Fiber Selection section
 2. Select one or more OB codes from the list
-3. **Fiber IDs automatically populate** with corresponding fibers
-4. See bidirectional synchronization (below)
+3. **Fiber IDs and table checkboxes automatically update**
 
-#### Method 2: Select by Fiber ID
+#### Method 3: Select by Fiber ID
 
 **Fiber ID** ranges from 1 to 2604.
 
@@ -166,28 +179,29 @@ Common examples:
 
 1. Click the **Fiber ID** dropdown in Fiber Selection section
 2. Select one or more fiber IDs from the list (can search by typing)
-3. **OB Codes automatically populate** with corresponding codes
-4. See bidirectional synchronization (below)
+3. **OB Codes and table checkboxes automatically update**
 
-#### Bidirectional Synchronization
+#### Three-way Bidirectional Synchronization
 
-The OB Code and Fiber ID selections are **automatically linked**:
+All three selection methods are **automatically linked**:
 
-- Select OB Code → Fiber IDs auto-populate with matching fibers
-- Select Fiber ID → OB Codes auto-populate with matching codes
-- Add/remove selections in either box → other box updates automatically
-- Manual adjustments allowed: You can add/remove individual items freely
+- Select in **table** → Fiber ID & OB Code widgets update
+- Select **OB Code** → Fiber ID widget & table checkboxes update
+- Select **Fiber ID** → OB Code widget & table checkboxes update
+- Changes in any widget immediately reflect in the other two
+- Manual adjustments allowed: You can add/remove selections freely in any widget
 
-**Example**:
+**Example Workflow**:
 
-1. Select OB Code: `<user defined ob_code>`
-2. Fiber IDs automatically populate with all science fibers
-3. Manually remove a few fiber IDs
-4. OB Code remains `<user defined ob_code>` but with fewer fibers
+1. Filter Target Info table to show only `SCIENCE` targets with `GOOD` status
+2. Check 5 fibers in the table using checkboxes
+3. Fiber ID and OB Code widgets automatically show selected fibers
+4. Manually add 2 more fiber IDs using Fiber ID dropdown
+5. Table checkboxes update to show all 7 selected fibers
 
 ### Creating Individual 1D Plots
 
-1. **Select fibers** using OB Code or Fiber ID (see above)
+1. **Select fibers** using any of the three methods above (table checkboxes, OB Code, or Fiber ID)
 2. Click **"Show 1D Spectra"** button
 3. Wait for processing (~2-5 seconds)
 4. Application automatically switches to the **1D Spectra** tab

--- a/docs/user-guide/loading-data.md
+++ b/docs/user-guide/loading-data.md
@@ -106,6 +106,10 @@ An interactive table showing details for each fiber:
 **Table Features**:
 
 - **Pagination**: 250 rows per page
+- **Checkbox Selection**: Check rows to select fibers for 1D spectra plotting
+  - Click checkboxes to select individual fibers
+  - Selected rows automatically update **Fiber ID** and **OB Code** widgets in sidebar
+  - Selections sync bidirectionally: changes in sidebar also update table checkboxes
 - **Filtering**: Click column headers to filter by value
 - **Visual styling**:
   - **Bold text**: SCIENCE targets with GOOD status (important targets)
@@ -115,9 +119,10 @@ An interactive table showing details for each fiber:
 
 **Table Controls**:
 
-- Sort by clicking column headers
-- Filter using header text boxes
-- Navigate pages using pagination controls at bottom
+- **Select fibers**: Click checkboxes in leftmost column
+- **Sort**: Click column headers to sort
+- **Filter**: Use header text boxes to filter rows
+- **Navigate**: Use pagination controls at bottom
 
 ## Visit Auto-Refresh
 
@@ -211,9 +216,13 @@ You must manually select a visit from the dropdown. There is no automatic loadin
 After successfully loading visit data, you can:
 
 1. **View fiber configuration**: Already displayed in Target Info tab
-2. **Create 2D images**: See [2D Images Guide](2d-images.md)
-3. **View 1D spectra**: See [1D Spectra Guide](1d-spectra.md)
-4. **Select specific fibers**: Use OB Code or Fiber ID dropdowns for filtering
+2. **Select fibers for visualization**: Three ways to select fibers:
+   - Check rows in the **Target Info** table (checkbox column)
+   - Select from **OB Code** dropdown in sidebar
+   - Select from **Fiber ID** dropdown in sidebar
+   - All three methods sync automatically
+3. **Create 2D images**: See [2D Images Guide](2d-images.md)
+4. **View 1D spectra**: See [1D Spectra Guide](1d-spectra.md)
 
 ## See Also
 


### PR DESCRIPTION
## Summary

- Implemented three-way bidirectional synchronization for fiber selection
- Added checkbox selection to pfsConfig Tabulator widget
- Users can now select fibers via table, OB Code, or Fiber ID widgets
- All three methods sync automatically

## Changes

### User Interface
- Added checkbox column to Target Info table for direct fiber selection
- Frozen Fiber ID column to ensure visibility with checkbox selection
- Changed table layout from `fit_data_table` to `fit_columns` for optimal display

### Synchronization
- **Table → Widgets**: Checking rows updates Fiber ID and OB Code dropdowns
- **OB Code → Table**: Selecting OB codes updates Fiber IDs and table checkboxes
- **Fiber ID → Table**: Selecting Fiber IDs updates OB codes and table checkboxes
- Circular reference prevention via `programmatic_update` flag

### Technical Implementation
- `on_tabulator_selection_change()`: New callback for table selection changes
- Enhanced `on_obcode_change()`: Now updates table checkbox selection
- Enhanced `on_fiber_change()`: Now updates table checkbox selection
- Updated `clear_selection_callback()`: Clears all three widgets

### Documentation
- Updated CLAUDE.md with three-way synchronization details
- Updated README.md key features section
- Enhanced user guides with table selection instructions
- Added practical workflow examples

## Test plan

- [x] Load a visit and verify Target Info table displays with checkboxes
- [x] Check rows in table and verify Fiber ID/OB Code widgets update
- [x] Select OB Code and verify table checkboxes update
- [x] Select Fiber IDs and verify table checkboxes update
- [x] Use "Clear Selection" and verify all widgets clear
- [x] Create 1D spectra plot using table selection
- [x] Verify bidirectional sync works across all three methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)