### PR TITLE
Fix: Use add_next_tick_callback for proper notification timing

### DIFF
--- a/app.py
+++ b/app.py
@@ -607,10 +607,14 @@ def load_data_callback(event=None):
             f"**Loaded visit {visit}**: {num_fibers} fibers, {num_obcodes} OB codes"
         )
 
-        # Switch to Target Info tab to show loaded data (before notification to prevent dismissal)
+        # Switch to Target Info tab to show loaded data
         tabs.active = 0
-        pn.state.notifications.success(
-            f"Visit {visit} loaded successfully", duration=2000
+
+        # Show notification on next tick to avoid race condition with widget/tab updates
+        show_notification_on_next_tick(
+            f"Visit {visit} loaded successfully",
+            notification_type="success",
+            duration=2000
         )
 
         log_md.object = f"""**Data loaded**
@@ -1492,7 +1496,6 @@ def on_session_created():
         f"Session started with DATASTORE={datastore}, BASE_COLLECTION={base_collection}, "
         f"OBSDATE_UTC={obsdate_utc}, VISIT_REFRESH_INTERVAL={refresh_interval}s"
     )
-    pn.state.notifications.info("Configuration reloaded from .env file", duration=3000)
 
     # Initialize session state and store configuration
     session_state = get_session_state()
@@ -1508,6 +1511,13 @@ def on_session_created():
         f"**Datastore:** {datastore}<br>"
         f"**Base collection:** {base_collection}<br>"
         f"**Observation Date (UTC):** {obsdate_utc}"
+    )
+
+    # Show notification on next tick to avoid race condition with widget updates
+    show_notification_on_next_tick(
+        "Configuration reloaded from .env file",
+        notification_type="info",
+        duration=3000
     )
 
     # Reset visit widget to loading state


### PR DESCRIPTION
## Summary

Replaces the `time.sleep(0.5)` workaround with Bokeh's official `add_next_tick_callback` API to properly schedule notifications after widget updates.

## Problem

In PR #68, we added a 500ms `time.sleep()` delay before showing notifications to avoid race conditions with Panel's widget rendering. While this worked, it had several drawbacks:
- Arbitrary delay that might not work in all environments
- Blocking call (though minimal impact in practice)
- Not using the proper API

## Investigation

Through testing, we confirmed that `pn.state.curdoc.add_next_tick_callback()` is available in Panel 1.8.2:

```
pn.state.curdoc type: <class 'bokeh.document.document.Document'>
Has add_next_tick_callback: True
```

This is Bokeh's official mechanism for scheduling callbacks to run on the next event loop tick, ensuring proper timing relative to widget updates.

## Solution

Added `show_notification_on_next_tick()` helper function that uses `pn.state.curdoc.add_next_tick_callback()` to schedule notification display:

```python
def show_notification_on_next_tick(message, notification_type="info", duration=3000):
    """Show notification on next Bokeh event loop tick"""
    def _show_notification():
        # Display notification based on type
        ...
    
    pn.state.curdoc.add_next_tick_callback(_show_notification)
```

Applied to all notification calls in `check_visit_discovery()`:
- ✅ Success case (visits found)
- ✅ No data case (no visits found) 
- ✅ Error case (discovery failed)

## Benefits

- **Non-blocking**: No `time.sleep()` delays
- **Proper timing**: Uses Bokeh's event loop instead of arbitrary delays
- **Environment-independent**: Works regardless of server performance or network latency
- **Official API**: Uses documented Bokeh mechanism
- **Future-proof**: Follows best practices for Panel/Bokeh applications

## Changes

- Add `show_notification_on_next_tick()` helper function
- Replace all `pn.state.notifications.*()` calls with `show_notification_on_next_tick()` in visit discovery
- Remove `import time` (no longer needed)

## Testing

Tested with actual deployment and confirmed:
- Notifications display for full duration (no premature dismissal)
- Works for both "visits found" and "no visits found" cases
- Non-blocking behavior (UI remains responsive)

## Related

- Supersedes: #68
- Investigation: Confirmed via test app that `add_next_tick_callback` is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)