### PR TITLE
Fix sidebar widget alignment for cross-browser consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,9 @@ This is a web application for visualizing 2D and 1D spectral data from the PFS (
 - Automatic tab switching: switches to 2D/1D tab after plot creation
 - Fixed-height status display (60px) to prevent layout shifts
 - Responsive design with min/max width constraints (280-400px sidebar)
+  - All sidebar widgets use `sizing_mode="stretch_width"` for consistent alignment
+  - Cross-browser CSS ensures MultiChoice widgets respect container width
+  - Buttons and widgets align vertically without overflow
 - Non-blocking UI: visit discovery runs in background, UI remains responsive
 
 #### Workflow & Data Flow

--- a/app.py
+++ b/app.py
@@ -218,6 +218,7 @@ visit_mc = pn.widgets.MultiChoice(
     options=[],
     max_items=1,  # temporary limit to single visit mode
     placeholder="Loading visits...",  # Initial state shows loading
+    sizing_mode="stretch_width",
 )
 
 obcode_mc = pn.widgets.MultiChoice(
@@ -225,6 +226,7 @@ obcode_mc = pn.widgets.MultiChoice(
     options=[],
     option_limit=20,
     search_option_limit=10,
+    sizing_mode="stretch_width",
 )
 
 fibers_mc = pn.widgets.MultiChoice(
@@ -232,12 +234,12 @@ fibers_mc = pn.widgets.MultiChoice(
     options=np.arange(1, 2605, dtype=int).tolist(),
     option_limit=20,
     search_option_limit=10,
+    sizing_mode="stretch_width",
 )
 
 btn_clear_selection = pn.widgets.Button(
     name="Clear Selection",
     button_type="default",
-    min_width=140,
     sizing_mode="stretch_width",
 )
 
@@ -269,7 +271,6 @@ btn_plot_1d = pn.widgets.Button(
     name="Show 1D Spectra",
     button_type="primary",
     disabled=True,
-    min_width=140,
     sizing_mode="stretch_width",
 )
 btn_reset = pn.widgets.Button(name="Reset", sizing_mode="stretch_width")
@@ -1592,7 +1593,10 @@ sidebar = pn.Column(
     # btn_clear_selection,
     obcode_mc,
     fibers_mc,
-    pn.Row(btn_plot_1d, btn_clear_selection),
+    pn.Column(
+        pn.Row(btn_plot_1d, btn_clear_selection, sizing_mode="stretch_width"),
+        sizing_mode="stretch_width",
+    ),
     pn.layout.Divider(),
     pn.Column(btn_reset),
     pn.layout.Divider(),
@@ -1619,6 +1623,19 @@ pn.template.FastListTemplate(
 
         :root {
             --body-font: 'Inter', sans-serif !important;
+        }
+
+        /* Ensure MultiChoice widgets respect container width across all browsers */
+        .bk-input.bk-input-group {
+            box-sizing: border-box !important;
+            max-width: 100% !important;
+            width: 100% !important;
+        }
+
+        /* Ensure MultiChoice input fields don't overflow */
+        .bk-input.bk-input-group input {
+            box-sizing: border-box !important;
+            max-width: 100% !important;
         }
         """
     ],


### PR DESCRIPTION
## Summary

- Improves sidebar widget alignment to ensure consistent display across all browser engines (Chrome, Firefox, Safari)
- Fixes issue where MultiChoice widgets and button rows were overflowing sidebar width constraints

## Changes

### Widget Sizing
- Added `sizing_mode="stretch_width"` to all MultiChoice widgets (visit, obcode, fibers)
- Removed `min_width=140` from `btn_plot_1d` and `btn_clear_selection` buttons
- Wrapped button Row in Column with proper sizing mode for width control

### Cross-Browser CSS
- Added CSS rules to ensure MultiChoice widgets respect container width:
  - `box-sizing: border-box` for consistent padding/border calculation
  - `max-width: 100%` and `width: 100%` to prevent overflow
- Ensures consistent behavior across Blink, Gecko, and WebKit engines

### Documentation
- Updated CLAUDE.md to document responsive design improvements

## Test Plan

- [x] Test in Chrome/Brave (Blink engine)
- [x] Test in Firefox (Gecko engine)
- [x] Test in Safari (WebKit engine) - recommended
- [x] Verify all sidebar widgets align vertically without overflow
- [x] Verify MultiChoice widgets scale properly with sidebar width (280-400px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)