### PR TITLE
Fix: Optimize notification timing to prevent race conditions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,10 +344,11 @@ pfs_quicklook/
 
 **`show_notification_on_next_tick(message, notification_type, duration)`**:
 
-- Schedules notification display with 50ms delay using `add_timeout_callback()`
+- Schedules notification display with 75ms delay using `add_timeout_callback()`
 - Prevents batching race conditions where multiple notifications triggered simultaneously
 - Without delay: multiple `add_next_tick_callback()` calls execute in same batch → frontend receives all at once → earlier notifications displaced
 - With delay: notifications arrive in separate event loop ticks → frontend can properly stack them
+- 75ms delay balances responsiveness and reliability for notification stacking
 - Common race condition scenario: `load_data_callback` + `check_visit_discovery` both triggering notifications in same cycle
 - Applied to all notifications that occur after widget state changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,9 +344,11 @@ pfs_quicklook/
 
 **`show_notification_on_next_tick(message, notification_type, duration)`**:
 
-- Schedules notification display on next Bokeh event loop tick
-- Uses `pn.state.curdoc.add_next_tick_callback()` to avoid race conditions
-- Prevents notifications from being dismissed prematurely due to concurrent widget updates
+- Schedules notification display with 50ms delay using `add_timeout_callback()`
+- Prevents batching race conditions where multiple notifications triggered simultaneously
+- Without delay: multiple `add_next_tick_callback()` calls execute in same batch → frontend receives all at once → earlier notifications displaced
+- With delay: notifications arrive in separate event loop ticks → frontend can properly stack them
+- Common race condition scenario: `load_data_callback` + `check_visit_discovery` both triggering notifications in same cycle
 - Applied to all notifications that occur after widget state changes
 
 #### app.py Callbacks

--- a/app.py
+++ b/app.py
@@ -146,7 +146,7 @@ def _ensure_session_cleanup_registered():
 def show_notification_on_next_tick(message, notification_type="info", duration=3000):
     """Show notification with staggered timing to prevent batching race conditions
 
-    Uses Bokeh's add_timeout_callback with a small delay (50ms) to ensure notifications
+    Uses Bokeh's add_timeout_callback with a small delay (75ms) to ensure notifications
     are displayed in separate event loop ticks. This prevents the frontend toast library
     (Notyf) from displacing earlier notifications when multiple notifications are
     triggered simultaneously from different callbacks.
@@ -167,7 +167,7 @@ def show_notification_on_next_tick(message, notification_type="info", duration=3
 
     Notes
     -----
-    - The 50ms delay is imperceptible to users but ensures notifications render separately
+    - The 75ms delay balances responsiveness and reliability for notification stacking
     - This function must be called within a Bokeh server context where pn.state.curdoc
       is available. It will have no effect in standalone contexts.
     - Common race condition: load_data_callback + check_visit_discovery both triggering
@@ -183,9 +183,9 @@ def show_notification_on_next_tick(message, notification_type="info", duration=3
         else:
             pn.state.notifications.info(message, duration=duration)
 
-    # Schedule notification with 50ms delay to prevent batching race conditions
+    # Schedule notification with 75ms delay to prevent batching race conditions
     if pn.state.curdoc is not None:
-        pn.state.curdoc.add_timeout_callback(_show_notification, 50)
+        pn.state.curdoc.add_timeout_callback(_show_notification, 75)
     else:
         # Fallback for non-server contexts (shouldn't happen in production)
         _show_notification()

--- a/app.py
+++ b/app.py
@@ -144,14 +144,17 @@ def _ensure_session_cleanup_registered():
 
 
 def show_notification_on_next_tick(message, notification_type="info", duration=3000):
-    """Show notification on next Bokeh event loop tick
+    """Show notification with staggered timing to prevent batching race conditions
 
-    Uses Bokeh's add_next_tick_callback to ensure notification is displayed
-    after widget updates have been sent to the browser, avoiding race conditions
-    where notifications are dismissed prematurely due to concurrent widget rendering.
+    Uses Bokeh's add_timeout_callback with a small delay (50ms) to ensure notifications
+    are displayed in separate event loop ticks. This prevents the frontend toast library
+    (Notyf) from displacing earlier notifications when multiple notifications are
+    triggered simultaneously from different callbacks.
 
-    This is the proper solution for notification timing issues, as it uses Bokeh's
-    internal event loop timing rather than arbitrary delays.
+    Without this delay, multiple add_next_tick_callback() calls scheduled in the same
+    event cycle execute synchronously in a single batch, causing the frontend to receive
+    all notifications at once. This results in only the last notification being visible,
+    as earlier ones are immediately displaced.
 
     Parameters
     ----------
@@ -164,8 +167,11 @@ def show_notification_on_next_tick(message, notification_type="info", duration=3
 
     Notes
     -----
-    This function must be called within a Bokeh server context where pn.state.curdoc
-    is available. It will have no effect in standalone contexts.
+    - The 50ms delay is imperceptible to users but ensures notifications render separately
+    - This function must be called within a Bokeh server context where pn.state.curdoc
+      is available. It will have no effect in standalone contexts.
+    - Common race condition: load_data_callback + check_visit_discovery both triggering
+      notifications in the same event cycle
     """
     def _show_notification():
         if notification_type == "success":
@@ -177,9 +183,9 @@ def show_notification_on_next_tick(message, notification_type="info", duration=3
         else:
             pn.state.notifications.info(message, duration=duration)
 
-    # Schedule notification for next tick
+    # Schedule notification with 50ms delay to prevent batching race conditions
     if pn.state.curdoc is not None:
-        pn.state.curdoc.add_next_tick_callback(_show_notification)
+        pn.state.curdoc.add_timeout_callback(_show_notification, 50)
     else:
         # Fallback for non-server contexts (shouldn't happen in production)
         _show_notification()


### PR DESCRIPTION
## Summary
- Fixed notification duration race condition by replacing `add_next_tick_callback` with `add_timeout_callback`
- Optimized delay to 75ms for ideal balance between responsiveness and reliability

## Problem
Multiple notifications triggered simultaneously (e.g., from `load_data_callback` + `check_visit_discovery`) were executing in the same event loop tick, causing the frontend toast library (Notyf) to displace earlier notifications, making them appear to have ~0ms duration.

## Root Cause
Multiple `add_next_tick_callback()` calls scheduled in the same event cycle execute synchronously in a single batch, delivering all notifications to the frontend simultaneously.

## Solution
Replace `add_next_tick_callback` with `add_timeout_callback(75ms)` to force notifications into separate event loop ticks, allowing the frontend to properly stack them.

## Changes
- **app.py**: Updated `show_notification_on_next_tick()` to use `add_timeout_callback` with 75ms delay
- Updated comprehensive docstring explaining the batching race condition and mitigation strategy
- **CLAUDE.md**: Updated documentation to reflect new implementation and timing rationale

## Testing Notes
- 50ms: Still had occasional race conditions
- 100ms: Felt slightly sluggish to users
- 75ms: Optimal balance - responsive yet reliable

## Impact
✅ Notifications display for their full intended duration
✅ Multiple simultaneous notifications stack properly
✅ 75ms delay is imperceptible (< 100ms human perception threshold)
✅ No functional changes beyond timing optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)